### PR TITLE
Fixing first line of printed YAML

### DIFF
--- a/src/main/kotlin/tasks/YAML.kt
+++ b/src/main/kotlin/tasks/YAML.kt
@@ -12,7 +12,7 @@ class YAMLGenerator {
 
     file.bufferedWriter().use { out ->
       val resources = datamap["Resources"]!!;
-      out.write("data: ${resources.atoms(resources.TOP)}\n");
+      out.write("data: ${resources.atoms(resources.TOP).unwrap()}\n");
 
       out.write("rules:\n");
 


### PR DESCRIPTION
Just a missing unwrap()